### PR TITLE
destroy/error handling

### DIFF
--- a/test.js
+++ b/test.js
@@ -23,6 +23,12 @@ test('formats', function (t) {
 
 })
 
+test('errors', function(t) {
+  var tStream = errorStream.bind(this, t)
+  t.plan(1)
+  tStream(formatData('json'), '{"rows":[{"a":1,"b":2},{"error":"Oh no!"}]}')
+})
+
 function testStream(t, stream, expect) {
   stream.pipe(concat(function (result) {
     t.equals(result, expect)
@@ -30,5 +36,13 @@ function testStream(t, stream, expect) {
   stream.write({a: 1, b:2})
   stream.write({a: 'hello', b:'world'})
   stream.end()
+}
+
+function errorStream(t, stream, expect) {
+  stream.pipe(concat(function (result) {
+    t.equals(result, expect)
+  }))
+  stream.write({a: 1, b:2})
+  stream.destroy(new Error('Oh no!'))
 }
 


### PR DESCRIPTION
this is just for discussion purposes right now

discussion: how do you think we should handle errors in streaming JSON REST APIs? e.g. say a leveldb readstream has an error halfway through being piped into this https://github.com/finnp/format-data/blob/master/json.js, what should the response be?

this adds a simple test that tries to destroy the stream. 

one problem I see with this is: what if you have a legitimate piece of data with a key `error`? how would you differentiate between real data and actual errors in that case?

also currently the `json` formatter in this repo doesnt implement `.destroy` so the tests crash ATM
