### PR TITLE
bump csv-write-stream

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "homepage": "https://github.com/finnp/format-data",
   "dependencies": {
-    "csv-write-stream": "^0.2.2",
+    "csv-write-stream": "^1.0.0",
     "inherits": "^2.0.1",
     "ndjson": "^1.2.3",
     "ssejson": "^1.2.0"


### PR DESCRIPTION
csv-write-stream is at 1.0.0 now with various fixes. it does not break anything related to this module so this should be safe to merge
